### PR TITLE
inotifywait-polling.sh does not report file modifications if size did…

### DIFF
--- a/inotifywait-polling.sh
+++ b/inotifywait-polling.sh
@@ -124,13 +124,13 @@ done
 ##
 watch () {
     #echo "watch $1"
-    find $1 -printf "%s %y %p\\n" | sort -k3 - > $1.inotifywait
+    find $1 -printf "%s %y %p %T@\\n" | sort -k3 - > $1.inotifywait
     while true; do
         sleep 2
         sign=
         last=$(cat $1.inotifywait)
         #mv $1.inotifywait $1.$(date +%s).inotifywait
-        find $1 -printf "%s %y %p\\n" | sort -k3 - > $1.inotifywait
+        find $1 -printf "%s %y %p %T@\\n" | sort -k3 - > $1.inotifywait
         meta=$(diff <(echo "${last}") <(cat "$1.inotifywait")) && true
         [[ -z "${meta}" ]] && continue
         echo -e "${meta}\n." | while IFS= read line || [[ -n "${line}" ]]; do


### PR DESCRIPTION
I found inotifywait-polling.sh useful as a workaround for watching windows folders bindmounted into docker on WSL2.
Thanks for sharing the script. 👍 

But I noticed one defect - this version does not report file modifications that do not change size of the file, like typo fixes "teh" -> "the". There is simply not enough info in `.inotifywait` to detect this case.

Adding additional field with modification date `%@T` to `.inotifywait` file solved the problem for me, so I thought it would be good to share.