### PR TITLE
Add some features and fix bugs.

### DIFF
--- a/inotifywait-polling.sh
+++ b/inotifywait-polling.sh
@@ -131,7 +131,6 @@ watch () {
     [[ $watchtower != */ ]] && watchtower="$watchtower/"
     watchtower=$watchtower.$(echo $target | sed -e 's|\.||g' -e 's|^./||g; s|^/||g' -e 's|/$||g' | sed -e 's|/|-|g').inotifywait
 
-    find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
     #echo "watch $target"
     find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
     while true; do

--- a/inotifywait-polling.sh
+++ b/inotifywait-polling.sh
@@ -127,7 +127,11 @@ done
 ##
 watch () {
     target=$1
-    [[ -z ${watchtower} ]] && watchtower=$target
+    [[ -z ${watchtower} ]] && watchtower="$HOME"
+    [[ $watchtower != */ ]] && watchtower="$watchtower/"
+    watchtower=$watchtower.$(echo $target | sed -e 's|\.||g' -e 's|^./||g; s|^/||g' -e 's|/$||g' | sed -e 's|/|-|g').inotifywait
+
+    find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
     #echo "watch $target"
     find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
     while true; do

--- a/inotifywait-polling.sh
+++ b/inotifywait-polling.sh
@@ -106,7 +106,7 @@ EOF
 quiet=
 recursive=
 watchtower=
-options=$(getopt -n inotifywait -o qrhme: -l help -- "$@" && true)
+options=$(getopt -n inotifywait -o qrhmw:e: -l help -- "$@" && true)
 eval set -- "${options}"
 #echo "options: ${options}"
 

--- a/inotifywait-polling.sh
+++ b/inotifywait-polling.sh
@@ -126,15 +126,16 @@ done
 #
 ##
 watch () {
-    [[ -z ${watchtower} ]] && watchtower=$1
-    #echo "watch $watchtower"
-    find $watchtower -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
+    target=$1
+    [[ -z ${watchtower} ]] && watchtower=$target
+    #echo "watch $target"
+    find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
     while true; do
         sleep 2
         sign=
         last=$(cat $watchtower.inotifywait)
         #mv $watchtower.inotifywait $watchtower.$(date +%s).inotifywait
-        find $watchtower -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
+        find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
         meta=$(diff <(echo "${last}") <(cat "$watchtower.inotifywait")) && true
         [[ -z "${meta}" ]] && continue
         echo -e "${meta}\n." | while IFS= read line || [[ -n "${line}" ]]; do

--- a/inotifywait-polling.sh
+++ b/inotifywait-polling.sh
@@ -132,14 +132,14 @@ watch () {
     watchtower=$watchtower.$(echo $target | sed -e 's|\.||g' -e 's|^./||g; s|^/||g' -e 's|/$||g' | sed -e 's|/|-|g').inotifywait
 
     #echo "watch $target"
-    find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
+    find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower
     while true; do
         sleep 2
         sign=
-        last=$(cat $watchtower.inotifywait)
-        #mv $watchtower.inotifywait $watchtower.$(date +%s).inotifywait
-        find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
-        meta=$(diff <(echo "${last}") <(cat "$watchtower.inotifywait")) && true
+        last=$(cat $watchtower)
+        #mv $watchtower $watchtower.$(date +%s)
+        find $target -printf "%s %y %p\\n" | sort -k3 - > $watchtower
+        meta=$(diff <(echo "${last}") <(cat "$watchtower")) && true
         [[ -z "${meta}" ]] && continue
         echo -e "${meta}\n." | while IFS= read line || [[ -n "${line}" ]]; do
             #echo "line: $line"

--- a/inotifywait-polling.sh
+++ b/inotifywait-polling.sh
@@ -126,7 +126,7 @@ done
 #
 ##
 FILE_SEPARATOR=$'\x1F'
-GROUP_SEPARARTOR=$'\x1D'
+GROUP_SEPARATOR=$'\x1D'
 
 watch () {
     target=$1
@@ -180,20 +180,20 @@ watch () {
                 ">")
                     event='CREATE'
 
-                    data=${sign%%${GROUP_SEPARARTOR}*}
+                    data=${sign%%${GROUP_SEPARATOR}*}
                     if [[ "${data}" == *"DELETE:${file}"* ]]; then
                         event='MODIFY'
-                        sign=${sign#*${GROUP_SEPARARTOR}}
+                        sign=${sign#*${GROUP_SEPARATOR}}
                     elif [[ "${data}" == *"DELETE:"* ]]; then
                         event='MOVE'
 
                         deleted_file="${data#*:}"
-                        sign="${sign#*${GROUP_SEPARARTOR}}"
+                        sign="${sign#*${GROUP_SEPARATOR}}"
                         file="${deleted_file}${FILE_SEPARATOR}${file}"
                     fi
                     ;;
             esac
-            sign+="${event}:${file}${GROUP_SEPARARTOR}"
+            sign+="${event}:${file}${GROUP_SEPARATOR}"
         done
     done
     return 0

--- a/inotifywait-polling.sh
+++ b/inotifywait-polling.sh
@@ -41,37 +41,37 @@ inotifywait 3.14
 Wait for a particular event on a file or set of files.
 Usage: inotifywait [ options ] file1 [ file2 ] [ file3 ] [ ... ]
 Options:
-	-h|--help     	    Show this help text.
-	@<file>       	    Exclude the specified file from being watched.
+	-h|--help	 	Show this help text.
+	@<file>	   		Exclude the specified file from being watched.
 	--exclude <pattern>
-	              	    Exclude all events on files matching the
-	              	    extended regular expression <pattern>.
+				  	Exclude all events on files matching the
+				  	extended regular expression <pattern>.
 	--excludei <pattern>
-	              	    Like --exclude but case insensitive.
-    -w|--watchtower     Set the file path where monitoring information is stored.
-	-m|--monitor  	    Keep listening for events forever.  Without
-	              	    this option, inotifywait will exit after one
-	              	    event is received.
-	-d|--daemon   	    Same as --monitor, except run in the background
-	              	    logging events to a file specified by --outfile.
-	              	    Implies --syslog.
-	-r|--recursive	    Watch directories recursively.
+				  	Like --exclude but case insensitive.
+	-w|--watchtower	Set the file path where monitoring information is stored.
+	-m|--monitor  	Keep listening for events forever.  Without
+				  	this option, inotifywait will exit after one
+				  	event is received.
+	-d|--daemon   	Same as --monitor, except run in the background
+				  	logging events to a file specified by --outfile.
+				  	Implies --syslog.
+	-r|--recursive	Watch directories recursively.
 	--fromfile <file>
-	              	    Read files to watch from <file> or `-' for stdin.
+				  	Read files to watch from <file> or `-' for stdin.
 	-o|--outfile <file>
-	              	    Print events to <file> rather than stdout.
-	-s|--syslog   	    Send errors to syslog rather than stderr.
-	-q|--quiet    	    Print less (only print events).
-	-qq           	    Print nothing (not even events).
-	--format <fmt>	    Print using a specified printf-like format
-	              	    string; read the man page for more details.
-	--timefmt <fmt>	    strftime-compatible format string for use with
-	              	    %T in --format string.
-	-c|--csv      	    Print events in CSV format.
+				  	Print events to <file> rather than stdout.
+	-s|--syslog   	Send errors to syslog rather than stderr.
+	-q|--quiet		Print less (only print events).
+	-qq		   		Print nothing (not even events).
+	--format <fmt>	Print using a specified printf-like format
+				  	string; read the man page for more details.
+	--timefmt <fmt>	strftime-compatible format string for use with
+				  	%T in --format string.
+	-c|--csv	  	Print events in CSV format.
 	-t|--timeout <seconds>
-	              	    When listening for a single event, time out after
-	              	    waiting for an event for <seconds> seconds.
-	              	    If <seconds> is 0, inotifywait will never time out.
+					When listening for a single event, time out after
+					waiting for an event for <seconds> seconds.
+					If <seconds> is 0, inotifywait will never time out.
 	-e|--event <event1> [ -e|--event <event2> ... ]
 		Listen for specific event(s).  If omitted, all events are
 		listened for.
@@ -79,18 +79,18 @@ Options:
 Exit status:
 	0  -  An event you asked to watch for was received.
 	1  -  An event you did not ask to watch for was received
-	      (usually delete_self or unmount), or some error occurred.
+		  (usually delete_self or unmount), or some error occurred.
 	2  -  The --timeout option was given and no events occurred
-	      in the specified interval of time.
+		  in the specified interval of time.
 
 Events:
 	access		file or directory contents were read
 	modify		file or directory contents were written
 	attrib		file or directory attributes changed
 	close_write	file or directory closed, after being opened in
-	           	writable mode
+				writable mode
 	close_nowrite	file or directory closed, after being opened in
-	           	read-only mode
+				read-only mode
 	close		file or directory closed, regardless of read/write mode
 	open		file or directory opened
 	moved_to	file or directory moved to watched directory
@@ -114,7 +114,7 @@ while true; do
     case "$1" in
         -q) quiet=1 ;;
         -r) recursive=1 ;;
-        -w) watchtower=1 ;;
+        -w) shift; watchtower=${1} ;;
         -e) shift; events=${1^^} ;;
         -h|--help) usage; exit ;;
         --) shift; break ;;
@@ -126,7 +126,7 @@ done
 #
 ##
 watch () {
-    if [[ -z ${watchtower} ]] && watchtower=$1
+    [[ -z ${watchtower} ]] && watchtower=$1
     #echo "watch $watchtower"
     find $watchtower -printf "%s %y %p\\n" | sort -k3 - > $watchtower.inotifywait
     while true; do


### PR DESCRIPTION
I came across the code to detect file events on an NFS-mounted volume. It seems that it hasn't been updated. So, I added a few features and fixed some bugs.

### New Features
- Added MOVE Event: Now, if a file name is changed in the watching directory, it will be detected.
- Added Interval Option (-i): Now, you can set the polling interval.
- Added Watchtower Option (-w): This script is implemented using find. You can set the path for the context file to check for differences.

### Bug Fixes
- Fixed abnormal event detection for MOVE_FROM, MOVE_TO, etc. I noticed and fixed the issue where the result of the following command was coming out incorrectly:
```bash
   $ touch test1 test2 test3 && rm test1 test2  && mv test3
```
- All changes to a file are detected based on the inode. If the inode is the same and there is a change to the file, it will be detected as MODIFY. If the inode is the same and the file name is changed, it will be detected as MOVE.
- Fixed a bug where the parsing becomes abnormal if there are spaces in the file name or directory path.